### PR TITLE
Error Handling in `SubscribeSlot`

### DIFF
--- a/service.go
+++ b/service.go
@@ -128,14 +128,18 @@ func (ifc *Interface) PublishSignal(signal string, poz ...PayloadObject) error {
 		Persist:        true,
 	})
 }
-func (ifc *Interface) SubscribeSlot(slot string, cb func(*SimpleMessage)) {
-	rc := ifc.svc.cl.SubscribeOrExit(&SubscribeParams{
+func (ifc *Interface) SubscribeSlot(slot string, cb func(*SimpleMessage)) error {
+	rc, err := ifc.svc.cl.Subscribe(&SubscribeParams{
 		URI:       ifc.SlotURI(slot),
 		AutoChain: true,
 	})
+	if err != nil {
+		return err
+	}
 	go func() {
 		for sm := range rc {
 			cb(sm)
 		}
 	}()
+	return nil
 }


### PR DESCRIPTION
I have changed `SubscribeSlot` to return an error when something goes wrong instead of exiting. This will make proper error handling much easier in Spawnpoint.

I suppose we could always add a `SubscribeSlotOrExit` if we really want to.