### PR TITLE
Fix bug in Text Representation of Generic Payload Objects

### DIFF
--- a/pobasic.go
+++ b/pobasic.go
@@ -78,7 +78,7 @@ func (po *PayloadObjectImpl) GetPODotNum() string {
 	return fmt.Sprintf("%d.%d.%d.%d", po.ponum>>24, (po.ponum>>16)&0xFF, (po.ponum>>8)&0xFF, po.ponum&0xFF)
 }
 func (po *PayloadObjectImpl) TextRepresentation() string {
-	return fmt.Sprintf("PO %s len %d (generic) hexdump:", PONumDotForm(po.ponum), len(po.contents), hex.Dump(po.contents))
+	return fmt.Sprintf("PO %s len %d (generic) hexdump:\n%s", PONumDotForm(po.ponum), len(po.contents), hex.Dump(po.contents))
 }
 func (po *PayloadObjectImpl) IsType(ponum, mask int) bool {
 	return (ponum >> uint(32-mask)) == (po.ponum >> uint(32-mask))


### PR DESCRIPTION
This is a one-line change. Before the fix, generic payload objects look like this:
```
PO 64.0.0.0 len 19 (generic) hexdump:%!(EXTRA string=00000000  49 20 61 6d 20 53 61 6d  2e 20 53 61 6d 20 49 20  |I am Sam. Sam I |
00000010  61 6d 2e                                          |am.|
)
```

After the fix, they look much better:
```
PO 64.0.0.0 len 19 (generic) hexdump:
00000000  49 20 61 6d 20 53 61 6d  2e 20 53 61 6d 20 49 20  |I am Sam. Sam I |
00000010  61 6d 2e                                          |am.|
```