### PR TITLE
Slot Unsubscribe, Opt out of Metadata Heartbeats

### DIFF
--- a/service.go
+++ b/service.go
@@ -42,6 +42,12 @@ func (cl *BW2Client) RegisterService(baseuri string, name string) *Service {
 	return rv
 }
 
+func (cl *BW2Client) RegisterServiceNoHb(baseuri string, name string) *Service {
+	baseuri = strings.TrimSuffix(baseuri, "/")
+	rv := &Service{cl: cl, baseuri: baseuri, name: name, mu: &sync.Mutex{}}
+	return rv
+}
+
 func (s *Service) registerLoop() {
 	//Initial delay is lower
 	time.Sleep(1 * time.Second)

--- a/service.go
+++ b/service.go
@@ -162,3 +162,18 @@ func (ifc *Interface) SubscribeSlot(slot string, cb func(*SimpleMessage)) error 
 	}()
 	return nil
 }
+func (ifc *Interface) SubscribeSlotH(slot string, cb func(*SimpleMessage)) (string, error) {
+	rc, handle, err := ifc.svc.cl.SubscribeH(&SubscribeParams{
+		URI:       ifc.SlotURI(slot),
+		AutoChain: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	go func() {
+		for sm := range rc {
+			cb(sm)
+		}
+	}()
+	return handle, nil
+}

--- a/serviceclient.go
+++ b/serviceclient.go
@@ -80,3 +80,20 @@ func (ifclient *InterfaceClient) SubscribeSignal(signal string, cb func(*SimpleM
 	}()
 	return nil
 }
+
+func (ifclient *InterfaceClient) SubscribeSignalH(signal string, cb func(*SimpleMessage)) (string, error) {
+	subChan, handle, err := ifclient.svc.cl.SubscribeH(&SubscribeParams{
+		URI:       ifclient.SignalURI(signal),
+		AutoChain: true,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	go func() {
+		for sm := range subChan {
+			cb(sm)
+		}
+	}()
+	return handle, nil
+}


### PR DESCRIPTION
These changes provide two new functions that allow users of the service/interface types to:
  1) Store an unsubscription handle for future use when initializing a slot subscription
  2) Register a service (and child interfaces) without implicitly launching a go-routine to publish metadata heartbeats

I am already using both of these features.